### PR TITLE
Change dockfile for only supporting sigmf ver1.0.0

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN /bin/bash -c "source ~/.bashrc" source ~/.bashrc
 RUN apt install -y net-tools
 
 # install sigmf and pytest 
-RUN pip3 install sigmf pytest
+RUN pip3 install sigmf==1.0.0 pytest
 
 # install python package to read TDMS files
 RUN pip3 install npTDMS[hdf,pandas,thermocouple_scaling]

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -17,7 +17,14 @@ Note that in order to mount a host directory into the volume, it is necessary to
 cd ../../
 ```
 - Then, run the docker container:
+
+**Windows PowerShell**
+```powershell
+set RFDATAFACTORYPATH=pwd
+sudo docker run -ti --rm --network host --privileged -v $RFDATAFACTORYPATH/build/docker/utils:/utils -v $RFDATAFACTORYPATH/src:/src user/ni-rf-data-recorder-api
 ```
+**Unix**
+```bash
 RFDATAFACTORYPATH=`pwd`
 sudo docker run -ti --rm --network host --privileged -v $RFDATAFACTORYPATH/build/docker/utils:/utils -v $RFDATAFACTORYPATH/src:/src user/ni-rf-data-recorder-api
 ```

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -17,14 +17,7 @@ Note that in order to mount a host directory into the volume, it is necessary to
 cd ../../
 ```
 - Then, run the docker container:
-
-**Windows PowerShell**
-```powershell
-set RFDATAFACTORYPATH=pwd
-sudo docker run -ti --rm --network host --privileged -v $RFDATAFACTORYPATH/build/docker/utils:/utils -v $RFDATAFACTORYPATH/src:/src user/ni-rf-data-recorder-api
 ```
-**Unix**
-```bash
 RFDATAFACTORYPATH=`pwd`
 sudo docker run -ti --rm --network host --privileged -v $RFDATAFACTORYPATH/build/docker/utils:/utils -v $RFDATAFACTORYPATH/src:/src user/ni-rf-data-recorder-api
 ```


### PR DESCRIPTION
As the Sigmf upgrade, there would be an "Assertion error" if users use sigmf newer than 1.0.0
![image](https://github.com/genesys-neu/ni-rf-data-recording-api/assets/101655210/443e45f9-2b08-4d88-a165-db492db5df57)

This pull request is based on this issue. When build docker, would install only sigmf version same as 1.0.0